### PR TITLE
Add Application Insights integration

### DIFF
--- a/src/AzureRenderManager/WebApp/Program.cs
+++ b/src/AzureRenderManager/WebApp/Program.cs
@@ -6,17 +6,16 @@ using Microsoft.Azure.KeyVault;
 using Microsoft.Azure.Services.AppAuthentication;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Configuration.AzureKeyVault;
+using System.Threading.Tasks;
 
 namespace WebApp
 {
     public class Program
     {
-        public static void Main(string[] args)
-        {
-            CreateWebHostBuilder(args).Build().Run();
-        }
+        public static Task Main(string[] args)
+            => CreateWebHost(args).RunAsync();
 
-        public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
+        public static IWebHost CreateWebHost(string[] args) =>
             WebHost.CreateDefaultBuilder(args)
                 .ConfigureAppConfiguration((context, config) =>
                 {
@@ -30,6 +29,7 @@ namespace WebApp
                         client,
                         new DefaultKeyVaultSecretManager());
                 })
-                .UseStartup<Startup>();
+                .UseStartup<Startup>()
+                .Build(); 
     }
 }

--- a/src/AzureRenderManager/WebApp/Startup.cs
+++ b/src/AzureRenderManager/WebApp/Startup.cs
@@ -1,17 +1,14 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 using System;
-using System.Threading;
 using System.Threading.Tasks;
-
+using Microsoft.ApplicationInsights;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Authentication.OpenIdConnect;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.Azure.KeyVault;
-using Microsoft.Azure.Services.AppAuthentication;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -79,13 +76,6 @@ namespace WebApp
                         };
                 });
 
-            // shared logging
-            services.AddLogging(c =>
-            {
-                c.AddConsole();
-                c.AddDebug();
-            });
-
             // Session state cache
             services.AddDistributedMemoryCache();
             services.AddSession(options =>
@@ -100,6 +90,10 @@ namespace WebApp
                 x.ValueLengthLimit = int.MaxValue;
                 x.MultipartBodyLengthLimit = int.MaxValue; // In case of multipart
             });
+
+            // Add Application Insights integration:
+            services.AddApplicationInsightsTelemetry(Configuration);
+            services.AddLogging(c => c.AddApplicationInsights());
 
             services.AddSingleton(
                 p =>

--- a/src/AzureRenderManager/WebApp/WebApp.csproj
+++ b/src/AzureRenderManager/WebApp/WebApp.csproj
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="BuildBundlerMinifier" Version="2.8.391" />
-    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.7.1" />
+    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.6.0" />
     <PackageReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.AspNetCore.AzureKeyVault.HostingStartup" Version="2.0.2" />
     <PackageReference Include="Microsoft.Azure.Batch" Version="10.0.0" />
@@ -23,6 +23,7 @@
     <PackageReference Include="Microsoft.Azure.Management.Network" Version="5.0.0" />
     <PackageReference Include="Microsoft.Azure.Management.ResourceManager" Version="2.0.0-preview" />
     <PackageReference Include="Microsoft.Azure.Management.Storage" Version="9.2.0-preview" />
+    <PackageReference Include="Microsoft.Extensions.Logging.ApplicationInsights" Version="2.9.0-beta3" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.1.1" />
     <PackageReference Include="TaskTupleAwaiter" Version="1.1.2" />
     <PackageReference Include="WindowsAzure.Storage" Version="9.3.0" />

--- a/src/AzureRenderManager/WebApp/appsettings.Development.json
+++ b/src/AzureRenderManager/WebApp/appsettings.Development.json
@@ -20,7 +20,9 @@
     "ObjectId": ""
   },
   "ApplicationInsights": {
-    "InstrumentationKey": ""
+    "TelemetryChannel": {
+      "DeveloperMode": true
+    }
   },
   "SubscriptionId": "",
   "Location": "{e.g. westus2}"

--- a/src/AzureRenderManager/WebApp/appsettings.json
+++ b/src/AzureRenderManager/WebApp/appsettings.json
@@ -34,9 +34,6 @@
     "StartTaskScriptWindows": "",
     "StartTaskScriptLinux": ""
   },
-  "ApplicationInsights": {
-    "InstrumentationKey": ""
-  },
   "BatchInsightsUrl": "https://renderfarmmgrdev.blob.core.windows.net/publicscripts/batch-insights.exe",
   "BatchInsightsProcessesToWatch": "3dsmax.exe,3dsmaxcmd.exe,3dsmaxio.exe,3dsmaxcmdio.exe,render.exe,mayabatch.exe,kick.exe,commandline.exe,cinema 4d.exe,vray.exe,maya.exe,blender.exe",
   "SubscriptionId": "",


### PR DESCRIPTION
This requires a key `ApplicationInsights:InstrumentationKey` to function. (This is already set up in the ARM template for the service.)

This should really work just via `UseApplicationInsights` on the `WebHost` builder but it seems to circumvent non-appsettings configs somehow, so we have to install it "manually" in `Startup`.