### PR TITLE
Allow viewing cost data for other months

### DIFF
--- a/src/AzureRenderManager/WebApp/Controllers/ReportingController.cs
+++ b/src/AzureRenderManager/WebApp/Controllers/ReportingController.cs
@@ -69,7 +69,15 @@ namespace WebApp.Controllers
             => Url.RouteUrl(nameof(Index), new { from = PrevMonthStart(period.From), to = PrevMonthEnd(period.From) });
 
         public string GetNextMonthLink(QueryTimePeriod period)
-            => Url.RouteUrl(nameof(Index), new { from = NextMonthStart(period.To), to = NextMonthEnd(period.To) });
+        {
+            var now = DateTimeOffset.UtcNow;
+            if (period.To >= now)
+            {
+                return null;
+            }
+
+            return Url.RouteUrl(nameof(Index), new { from = NextMonthStart(period.To), to = NextMonthEnd(period.To) });
+        }
 
         public static QueryTimePeriod GetQueryPeriod(DateTimeOffset? from, DateTimeOffset? to)
         {

--- a/src/AzureRenderManager/WebApp/Controllers/ReportingController.cs
+++ b/src/AzureRenderManager/WebApp/Controllers/ReportingController.cs
@@ -30,21 +30,99 @@ namespace WebApp.Controllers
         }
 
         [HttpGet]
-        [Route("Reporting")]
-        public async Task<ActionResult> Index()
+        [Route("Reporting", Name = nameof(Index))]
+        public async Task<ActionResult> Index([FromQuery] DateTimeOffset? from, [FromQuery] DateTimeOffset? to)
         {
             var (envs, client) = await (Environments(), _clientAccessor.GetClient());
 
-            var usages = await Task.WhenAll(envs.Select(env => GetUsage(client, env)));
+            var period = GetQueryPeriod(from, to);
 
-            return View(usages);
+            var usages = await Task.WhenAll(envs.Select(env => GetUsage(client, env, period)));
+
+            var nextMonthLink = GetNextMonthLink(period);
+            var prevMonthLink = GetPrevMonthLink(period);
+
+            return View(new IndexModel(usages, nextMonthLink, prevMonthLink));
         }
 
-        private static async Task<(string envName, UsageResponse)> GetUsage(CostManagementClient client, RenderingEnvironment env)
+        public class IndexModel
+        {
+            public IndexModel(
+                (string env, UsageResponse usage)[] usages,
+                string nextMonth,
+                string prevMonth)
+            {
+                UsagePerEnvironment = new SortedDictionary<string, UsageResponse>(usages.ToDictionary(pair => pair.env, pair => pair.usage));
+                NextMonthLink = nextMonth;
+                PreviousMonthLink = prevMonth;
+            }
+
+            public SortedDictionary<string, UsageResponse> UsagePerEnvironment { get; }
+
+            public string NextMonthLink { get; }
+
+            public string PreviousMonthLink { get; }
+
+        }
+
+        public string GetPrevMonthLink(QueryTimePeriod period)
+            => Url.RouteUrl(nameof(Index), new { from = PrevMonthStart(period.From), to = PrevMonthEnd(period.From) });
+
+        public string GetNextMonthLink(QueryTimePeriod period)
+            => Url.RouteUrl(nameof(Index), new { from = NextMonthStart(period.To), to = NextMonthEnd(period.To) });
+
+        public static QueryTimePeriod GetQueryPeriod(DateTimeOffset? from, DateTimeOffset? to)
+        {
+            if (from == null && to == null)
+            {
+                return ThisMonth();
+            }
+            else if (to == null)
+            {
+                return new QueryTimePeriod(from: from.Value, to: EndOfMonth(from.Value));
+            }
+            else if (from == null)
+            {
+                return new QueryTimePeriod(from: StartOfMonth(to.Value), to: to.Value);
+            }
+            else
+            {
+                return new QueryTimePeriod(from: from.Value, to: to.Value);
+            }
+        }
+
+        public static DateTimeOffset NextMonthStart(DateTimeOffset value)
+            => StartOfMonth(value).AddMonths(1);
+
+        public static DateTimeOffset NextMonthEnd(DateTimeOffset value)
+            => EndOfMonth(NextMonthStart(value));
+
+        public static DateTimeOffset PrevMonthStart(DateTimeOffset value)
+            => StartOfMonth(value).AddMonths(-1);
+
+        public static DateTimeOffset PrevMonthEnd(DateTimeOffset value)
+            => EndOfMonth(PrevMonthStart(value));
+
+        public static DateTimeOffset StartOfMonth(DateTimeOffset value)
+            => new DateTimeOffset(value.Year, value.Month, 1, 0, 0, 0, value.Offset);
+
+        public static DateTimeOffset EndOfMonth(DateTimeOffset value)
+            => NextMonthStart(value) - TimeSpan.FromSeconds(1);
+
+        public static QueryTimePeriod ThisMonth()
+        {
+            var today = DateTimeOffset.UtcNow;
+            return new QueryTimePeriod(from: StartOfMonth(today), to: EndOfMonth(today));
+        }
+
+        private static async Task<(string envName, UsageResponse)> GetUsage(
+            CostManagementClient client,
+            RenderingEnvironment env,
+            QueryTimePeriod timePeriod)
         {
             var usageRequest =
                 new UsageRequest(
-                    Timeframe.MonthToDate,
+                    Timeframe.Custom,
                     new Dataset(
                         Granularity.Daily,
                         new Dictionary<string, Aggregation>
@@ -56,6 +134,8 @@ namespace WebApp.Controllers
                             new Grouping("MeterSubCategory", ColumnType.Dimension)
                         },
                         FilterExpression.Tag("environment", Operator.In, new[] { env.Id })));
+
+            usageRequest.TimePeriod = timePeriod;
 
             return (env.Name, await client.GetUsageForResourceGroup(env.SubscriptionId, env.ResourceGroupName, usageRequest));
         }

--- a/src/AzureRenderManager/WebApp/CostManagement/JsonTypes.cs
+++ b/src/AzureRenderManager/WebApp/CostManagement/JsonTypes.cs
@@ -79,7 +79,23 @@ namespace WebApp.CostManagement
         [JsonConverter(typeof(StringEnumConverter))]
         public Timeframe Timeframe { get; }
 
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public QueryTimePeriod TimePeriod { get; set; }
+
         public Dataset Dataset { get; }
+    }
+
+    public class QueryTimePeriod
+    {
+        public QueryTimePeriod(DateTimeOffset from, DateTimeOffset to)
+        {
+            From = from;
+            To = to;
+        }
+
+        public DateTimeOffset From { get; }
+
+        public DateTimeOffset To { get; }
     }
 
     public class Dataset
@@ -214,6 +230,7 @@ namespace WebApp.CostManagement
 
     public enum Timeframe
     {
+        Custom,
         MonthToDate,
         YearToDate,
         WeekToDate,

--- a/src/AzureRenderManager/WebApp/Views/Reporting/Index.cshtml
+++ b/src/AzureRenderManager/WebApp/Views/Reporting/Index.cshtml
@@ -1,6 +1,6 @@
 ﻿@using Newtonsoft.Json;
 @using System.Linq;
-@model IReadOnlyList<(string envName, WebApp.CostManagement.UsageResponse data)>
+@model WebApp.Controllers.ReportingController.IndexModel
 @{
     ViewBag.Title = "Reporting";
 }
@@ -14,12 +14,38 @@
 
 <div class="page-header">
     <h1>Reporting</h1>
-    @foreach (var env in Model.OrderBy(env => env.envName))
+
+    @if(Model.PreviousMonthLink != null)
     {
-        <h2>@env.envName</h2>
-        @if (env.data.Properties == null)
+        <a href="@Model.PreviousMonthLink">Previous Month</a>
+
+        if (Model.NextMonthLink != null)
         {
-            <p>Cost not yet supported for this environment.</p>
+            <span>&bull;</span>
+        }
+    }
+
+    @if(Model.NextMonthLink != null)
+    {
+        <a href="@Model.NextMonthLink">Next Month</a>
+    }
+
+    @foreach (var kvp in Model.UsagePerEnvironment)
+    {
+        var envName = kvp.Key;
+        var data = kvp.Value;
+
+        <h2>@envName</h2>
+        @if (data.Properties == null)
+        {
+            <p>Cost management is not yet supported for this environment.</p>
+
+            continue;
+        }
+
+        @if (!data.Properties.Rows.Any())
+        {
+            <p>No cost data is available for this month.</p>
 
             continue;
         }
@@ -34,14 +60,14 @@
             </thead>
             <tbody>
                 @{
-                    var cols = env.data.Properties.Columns;
+                    var cols = data.Properties.Columns;
                     var dateIndex = cols.FindIndex(col => col.Name == "UsageDate");
                     var costIndex = cols.FindIndex(col => col.Name == "PreTaxCost");
                     var currencyIndex = cols.FindIndex(col => col.Name == "Currency");
                     var meterCategoryIndex = cols.FindIndex(col => col.Name == "MeterSubCategory");
                 }
 
-                @foreach (var day in env.data.Properties.Rows.GroupBy(row => row[dateIndex]).OrderBy(g => g.Key))
+                @foreach (var day in data.Properties.Rows.GroupBy(row => row[dateIndex]).OrderBy(g => g.Key))
                 {
                     string FormatCost(IReadOnlyList<object> row)
                         => string.Format("{0:0.00} {1}", row[costIndex], row[currencyIndex]);


### PR DESCRIPTION
This just has a basic previous month/next month link at the moment.

Reporting page still ugly, to be addressed in future 🙂 