### PR TITLE
Usage should be calculated per-sub not per-RG

### DIFF
--- a/src/AzureRenderManager/WebApp/Controllers/ReportingController.cs
+++ b/src/AzureRenderManager/WebApp/Controllers/ReportingController.cs
@@ -162,7 +162,7 @@ namespace WebApp.Controllers
 
                 usageRequest.TimePeriod = timePeriod;
 
-                return client.GetUsageForResourceGroup(env.SubscriptionId, env.ResourceGroupName, usageRequest);
+                return client.GetUsageForSubscription(env.SubscriptionId, usageRequest);
             }
         }
     }

--- a/src/AzureRenderManager/WebApp/CostManagement/CostManagementClient.cs
+++ b/src/AzureRenderManager/WebApp/CostManagement/CostManagementClient.cs
@@ -25,9 +25,9 @@ namespace WebApp.CostManagement
         private static Uri GetUri(string scope)
             => new Uri($"https://management.azure.com/{scope}/providers/Microsoft.CostManagement/query?api-version=2019-01-01");
 
-        public async Task<UsageResponse> GetUsageForResourceGroup(Guid subscriptionId, string resourceGroupName, UsageRequest usageRequest)
+        public async Task<UsageResponse> GetUsageForSubscription(Guid subscriptionId, UsageRequest usageRequest)
         {
-            var uri = GetUri($"subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}");
+            var uri = GetUri($"subscriptions/{subscriptionId}");
 
             var request =
                 new HttpRequestMessage(HttpMethod.Post, uri)


### PR DESCRIPTION
The items for a particular Environment are not necessarily all in the RG for that Environment (for example, the Storage server might be in a different RG). Instead we will get usage for the whole subscription and rely on the tags to filter it to the items we want.