### PR TITLE
Check classic admins when checking for user permissions

### DIFF
--- a/src/AzureRenderManager/WebApp/Arm/AzureResourceProvider.cs
+++ b/src/AzureRenderManager/WebApp/Arm/AzureResourceProvider.cs
@@ -90,10 +90,11 @@ namespace WebApp.Arm
             var classicAdmins = result.ToList();
             var user = GetUser();
             var names = user.Identities.Select(i => i.Claims.GetName());
+            var emails = user.Identities.Select(i => i.Claims.GetEmailAddress());
             var upns = user.Identities.Select(i => i.Claims.GetUpn());
             foreach (var adminEmail in GetClassicAdministratorEmails(classicAdmins))
             {
-                if (names.Contains(adminEmail) || upns.Contains(adminEmail))
+                if (names.Contains(adminEmail) || upns.Contains(adminEmail) || emails.Contains(adminEmail))
                 {
                     return true;
                 }

--- a/src/AzureRenderManager/WebApp/Arm/AzureResourceProvider.cs
+++ b/src/AzureRenderManager/WebApp/Arm/AzureResourceProvider.cs
@@ -94,7 +94,7 @@ namespace WebApp.Arm
             var upns = user.Identities.Select(i => i.Claims.GetUpn());
             foreach (var adminEmail in GetClassicAdministratorEmails(classicAdmins))
             {
-                if (names.Contains(adminEmail) || upns.Contains(adminEmail) || emails.Contains(adminEmail))
+                if (names.Any(name => name.Contains(adminEmail)) || upns.Contains(adminEmail) || emails.Contains(adminEmail))
                 {
                     return true;
                 }

--- a/src/AzureRenderManager/WebApp/Arm/AzureResourceProvider.cs
+++ b/src/AzureRenderManager/WebApp/Arm/AzureResourceProvider.cs
@@ -30,6 +30,8 @@ using Microsoft.WindowsAzure.Storage.Auth;
 using Microsoft.WindowsAzure.Storage.File;
 using WebApp.Config;
 using WebApp.Operations;
+using WebApp.Code.Extensions;
+using System.Security.Claims;
 
 namespace WebApp.Arm
 {
@@ -70,14 +72,38 @@ namespace WebApp.Arm
             var token = new TokenCredentials(accessToken);
             var authClient = new AuthorizationManagementClient(token) { SubscriptionId = subscriptionId.ToString() };
 
+            var isClassicAdminTask = IsCurrentUserClassicAdministrator(authClient);
             var result = await GetRoleDefinitions(authClient, $"/subscriptions/{subscriptionId}");
             var roleDefs = result.Where(rd =>
                 rd.Permissions.Any(p =>
                     p.Actions.Any(a => ActionsThatCanCreate.Contains(a.ToLower(CultureInfo.InvariantCulture))))).ToList();
 
             var subscriptionRoles = await GetRoleAssignmentsForCurrentUser(authClient, subscriptionScope, roleDefs);
+            var isClassicAdmin = await isClassicAdminTask;
 
-            return subscriptionRoles.Any(ra => roleDefs.Any(rd => rd.Id == ra.RoleDefinitionId));
+            return isClassicAdmin || subscriptionRoles.Any(ra => roleDefs.Any(rd => rd.Id == ra.RoleDefinitionId));
+        }
+
+        private async Task<bool> IsCurrentUserClassicAdministrator(AuthorizationManagementClient authClient)
+        {
+            var result = await authClient.ClassicAdministrators.ListAsync();
+            var classicAdmins = result.ToList();
+            var user = GetUser();
+            var names = user.Identities.Select(i => i.Claims.GetName());
+            var upns = user.Identities.Select(i => i.Claims.GetUpn());
+            foreach (var adminEmail in GetClassicAdministratorEmails(classicAdmins))
+            {
+                if (names.Contains(adminEmail) || upns.Contains(adminEmail))
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        private IEnumerable<string> GetClassicAdministratorEmails(List<ClassicAdministrator> admins)
+        {
+            return admins.Where(a => a.Role.Contains("ServiceAdministrator") || a.Role.Contains("CoAdministrator")).Select(a => a.EmailAddress);
         }
 
         public async Task<bool> CanCreateRoleAssignments(
@@ -91,6 +117,7 @@ namespace WebApp.Arm
             var token = new TokenCredentials(accessToken);
             var authClient = new AuthorizationManagementClient(token) { SubscriptionId = subscriptionId.ToString() };
 
+            var isClassicAdminTask = IsCurrentUserClassicAdministrator(authClient);
             var result = await GetRoleDefinitions(authClient, $"/subscriptions/{subscriptionId}");
             var roleDefs = result.Where(rd =>
                 rd.Permissions.Any(p =>
@@ -100,9 +127,11 @@ namespace WebApp.Arm
             var subscriptionRolesTask = GetRoleAssignmentsForCurrentUser(authClient, subscriptionScope, roleDefs);
             var resourceGroupRoles = await GetRoleAssignmentsForCurrentUser(authClient, resourceGroupScope, roleDefs);
             var subscriptionRoles = await subscriptionRolesTask;
+            var isClassicAdmin = await isClassicAdminTask;
 
-            return subscriptionRoles.Any(ra => roleDefs.Any(rd => rd.Id == ra.RoleDefinitionId)) ||
-                   resourceGroupRoles.Any(ra => roleDefs.Any(rd => rd.Id == ra.RoleDefinitionId));
+            return isClassicAdmin || 
+                subscriptionRoles.Any(ra => roleDefs.Any(rd => rd.Id == ra.RoleDefinitionId)) ||
+                resourceGroupRoles.Any(ra => roleDefs.Any(rd => rd.Id == ra.RoleDefinitionId));
         }
 
         public async Task<ResourceGroup> CreateResourceGroupAsync(
@@ -661,7 +690,7 @@ namespace WebApp.Arm
             List<RoleDefinition> roleDefinitions)
         {
             var user = GetUser();
-            var ownerObjectId = user.Claims.FirstOrDefault(c => c.Type == "http://schemas.microsoft.com/identity/claims/objectidentifier")?.Value;
+            var ownerObjectId = user.Claims.GetObjectId();
             var filter = new ODataQuery<RoleAssignmentFilter>(f => f.PrincipalId == ownerObjectId);
             var result = await authClient.RoleAssignments.ListForScopeAsync(scope, filter);
             var roleAssignments = result.ToList();

--- a/src/AzureRenderManager/WebApp/Arm/AzureResourceProvider.cs
+++ b/src/AzureRenderManager/WebApp/Arm/AzureResourceProvider.cs
@@ -89,12 +89,12 @@ namespace WebApp.Arm
             var result = await authClient.ClassicAdministrators.ListAsync();
             var classicAdmins = result.ToList();
             var user = GetUser();
-            var names = user.Identities.Select(i => i.Claims.GetName());
-            var emails = user.Identities.Select(i => i.Claims.GetEmailAddress());
-            var upns = user.Identities.Select(i => i.Claims.GetUpn());
+            var names = user.Identities.Select(i => i.Claims.GetName()).ToList();
+            var emails = user.Identities.Select(i => i.Claims.GetEmailAddress()).ToList();
+            var upns = user.Identities.Select(i => i.Claims.GetUpn()).ToList();
             foreach (var adminEmail in GetClassicAdministratorEmails(classicAdmins))
             {
-                if (names.Any(name => name.Contains(adminEmail)) || upns.Contains(adminEmail) || emails.Contains(adminEmail))
+                if (names.Contains(adminEmail) || upns.Contains(adminEmail) || emails.Contains(adminEmail))
                 {
                     return true;
                 }

--- a/src/AzureRenderManager/WebApp/Arm/KeyVaultMsiClient.cs
+++ b/src/AzureRenderManager/WebApp/Arm/KeyVaultMsiClient.cs
@@ -108,7 +108,7 @@ namespace WebApp.Arm
             }
             catch (KeyVaultErrorException ex)
             {
-                if (ex.Body.Error.Code != "SecretNotFound")
+                if (ex.Body?.Error?.Code != "SecretNotFound")
                 {
                     throw new Exception($"Failed to set secret with principal: {azureServiceTokenProvider.PrincipalUsed}", ex);
                 }

--- a/src/AzureRenderManager/WebApp/Code/Extensions/AzureAdAuthenticationBuilderExtensions.cs
+++ b/src/AzureRenderManager/WebApp/Code/Extensions/AzureAdAuthenticationBuilderExtensions.cs
@@ -47,35 +47,6 @@ namespace WebApp.Code.Extensions
 
                 // trying to get refresh to work
                 options.Scope.Add("offline_access"); // allow refreshing
-
-                //options.Events.OnAuthorizationCodeReceived += async context =>
-                //{
-                //    var userId = context.Principal.FindFirst("http://schemas.microsoft.com/identity/claims/objectidentifier").Value;
-
-                //    var authContext = new AuthenticationContext(context.Options.Authority);
-                //    var clientCred = new ClientCredential(context.Options.ClientId, context.Options.ClientSecret);
-
-                //    AuthenticationResult authResult;
-                //    try
-                //    {
-                //        authResult =
-                //            await authContext.AcquireTokenSilentAsync(
-                //                context.Options.Resource,
-                //                clientCred,
-                //                new UserIdentifier(userId, UserIdentifierType.UniqueId));
-                //    }
-                //    catch (AdalSilentTokenAcquisitionException)
-                //    {
-                //        authResult =
-                //            await authContext.AcquireTokenByAuthorizationCodeAsync(
-                //                context.TokenEndpointRequest.Code,
-                //                new Uri(context.TokenEndpointRequest.RedirectUri, UriKind.RelativeOrAbsolute),
-                //                clientCred,
-                //                context.Options.Resource);
-                //    }
-
-                //    context.HandleCodeRedemption(authResult.AccessToken, context.ProtocolMessage.IdToken);
-                //};
             }
 
             public void Configure(OpenIdConnectOptions options)

--- a/src/AzureRenderManager/WebApp/Code/Extensions/ClaimsExtensions.cs
+++ b/src/AzureRenderManager/WebApp/Code/Extensions/ClaimsExtensions.cs
@@ -15,12 +15,22 @@ namespace WebApp.Code.Extensions
 
         public static string GetEmailAddress(this IEnumerable<Claim> claims)
         {
-            return claims.FirstOrDefault(c => c.Type == "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress")?.Value;
+            var email = claims.FirstOrDefault(c => c.Type == "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress")?.Value;
+            if (email == null)
+            {
+                email = claims.FirstOrDefault(c => c.Type == "http://schemas.xmlsoap.org/claims/EmailAddress")?.Value;
+            }
+            return email;
         }
 
         public static string GetUpn(this IEnumerable<Claim> claims)
         {
-            return claims.FirstOrDefault(c => c.Type == "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/upn")?.Value;
+            var upn = claims.FirstOrDefault(c => c.Type == "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/upn")?.Value;
+            if (upn == null)
+            {
+                upn = claims.FirstOrDefault(c => c.Type == "http://schemas.xmlsoap.org/claims/UPN")?.Value;
+            }
+            return upn;
         }
 
         public static string GetObjectId(this IEnumerable<Claim> claims)

--- a/src/AzureRenderManager/WebApp/Code/Extensions/ClaimsExtensions.cs
+++ b/src/AzureRenderManager/WebApp/Code/Extensions/ClaimsExtensions.cs
@@ -13,6 +13,11 @@ namespace WebApp.Code.Extensions
             return claims.FirstOrDefault(c => c.Type == "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name")?.Value;
         }
 
+        public static string GetEmailAddress(this IEnumerable<Claim> claims)
+        {
+            return claims.FirstOrDefault(c => c.Type == "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress")?.Value;
+        }
+
         public static string GetUpn(this IEnumerable<Claim> claims)
         {
             return claims.FirstOrDefault(c => c.Type == "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/upn")?.Value;

--- a/src/AzureRenderManager/WebApp/Code/Extensions/ClaimsExtensions.cs
+++ b/src/AzureRenderManager/WebApp/Code/Extensions/ClaimsExtensions.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Claims;
+using System.Threading.Tasks;
+
+namespace WebApp.Code.Extensions
+{
+    public static class ClaimsExtensions
+    {
+        public static string GetName(this IEnumerable<Claim> claims)
+        {
+            return claims.FirstOrDefault(c => c.Type == "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name")?.Value;
+        }
+
+        public static string GetUpn(this IEnumerable<Claim> claims)
+        {
+            return claims.FirstOrDefault(c => c.Type == "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/upn")?.Value;
+        }
+
+        public static string GetObjectId(this IEnumerable<Claim> claims)
+        {
+            return claims.FirstOrDefault(c => c.Type == "http://schemas.microsoft.com/identity/claims/objectidentifier")?.Value;
+        }
+
+        public static string GetTenantId(this IEnumerable<Claim> claims)
+        {
+            return claims.FirstOrDefault(c => c.Type == "http://schemas.microsoft.com/identity/claims/tenantid")?.Value;
+        }
+    }
+}

--- a/src/AzureRenderManager/WebApp/Code/Extensions/ClaimsExtensions.cs
+++ b/src/AzureRenderManager/WebApp/Code/Extensions/ClaimsExtensions.cs
@@ -8,39 +8,54 @@ namespace WebApp.Code.Extensions
 {
     public static class ClaimsExtensions
     {
+        private const string NameClaim = "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name";
+        private const string ObjectIdClaim = "http://schemas.microsoft.com/identity/claims/objectidentifier";
+        private const string TenantIdClaim = "http://schemas.microsoft.com/identity/claims/tenantid";
+        private const string EmailAddressClaim = "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress";
+        private const string EmailAddressAdFsClaim = "http://schemas.xmlsoap.org/claims/EmailAddress";
+        private const string UpnClaim = "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/upn";
+        private const string UpnAdFsClaim = "http://schemas.xmlsoap.org/claims/UPN";
+
         public static string GetName(this IEnumerable<Claim> claims)
         {
-            return claims.FirstOrDefault(c => c.Type == "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name")?.Value;
+            var name = claims.FirstOrDefault(c => c.Type == NameClaim)?.Value;
+            // names from Live and other accounts are prefixed with the provider,
+            // i.e. live.com#bob@contoso.com
+            if (name != null && name.Contains("#"))
+            {
+                name = name.Split("#")[1];
+            }
+            return name;
         }
 
         public static string GetEmailAddress(this IEnumerable<Claim> claims)
         {
-            var email = claims.FirstOrDefault(c => c.Type == "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress")?.Value;
+            var email = claims.FirstOrDefault(c => c.Type == EmailAddressClaim)?.Value;
             if (email == null)
             {
-                email = claims.FirstOrDefault(c => c.Type == "http://schemas.xmlsoap.org/claims/EmailAddress")?.Value;
+                email = claims.FirstOrDefault(c => c.Type == EmailAddressAdFsClaim)?.Value;
             }
             return email;
         }
 
         public static string GetUpn(this IEnumerable<Claim> claims)
         {
-            var upn = claims.FirstOrDefault(c => c.Type == "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/upn")?.Value;
+            var upn = claims.FirstOrDefault(c => c.Type == UpnClaim)?.Value;
             if (upn == null)
             {
-                upn = claims.FirstOrDefault(c => c.Type == "http://schemas.xmlsoap.org/claims/UPN")?.Value;
+                upn = claims.FirstOrDefault(c => c.Type == UpnAdFsClaim)?.Value;
             }
             return upn;
         }
 
         public static string GetObjectId(this IEnumerable<Claim> claims)
         {
-            return claims.FirstOrDefault(c => c.Type == "http://schemas.microsoft.com/identity/claims/objectidentifier")?.Value;
+            return claims.FirstOrDefault(c => c.Type == ObjectIdClaim)?.Value;
         }
 
         public static string GetTenantId(this IEnumerable<Claim> claims)
         {
-            return claims.FirstOrDefault(c => c.Type == "http://schemas.microsoft.com/identity/claims/tenantid")?.Value;
+            return claims.FirstOrDefault(c => c.Type == TenantIdClaim)?.Value;
         }
     }
 }

--- a/src/AzureRenderManager/WebApp/Identity/IdentityProvider.cs
+++ b/src/AzureRenderManager/WebApp/Identity/IdentityProvider.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Configuration;
+using WebApp.Code.Extensions;
 
 namespace WebApp.Identity
 {
@@ -30,10 +31,8 @@ namespace WebApp.Identity
         public Identity GetCurrentUserIdentity(HttpContext context)
         {
             // We need to give the owner (the current portal user) access
-            var ownerTenantId = Guid.Parse(context.User.Claims
-                .FirstOrDefault(c => c.Type == "http://schemas.microsoft.com/identity/claims/tenantid")?.Value);
-            var ownerObjectId = Guid.Parse(context.User.Claims
-                .FirstOrDefault(c => c.Type == "http://schemas.microsoft.com/identity/claims/objectidentifier")?.Value);
+            var ownerTenantId = Guid.Parse(context.User.Claims.GetTenantId());
+            var ownerObjectId = Guid.Parse(context.User.Claims.GetObjectId());
 
             return new Identity
             {


### PR DESCRIPTION
Classic admins don't have any role assignments and therefore don't pass the current resource creation and user assignment checks.