### PR TITLE
Look up costs by resource group rather than subscription

### DIFF
--- a/src/AzureRenderManager/WebApp.Tests/UsageTests.cs
+++ b/src/AzureRenderManager/WebApp.Tests/UsageTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Text;
+using System.Linq;
+using WebApp.Config;
 using WebApp.CostManagement;
 using WebApp.Models.Reporting;
 using Xunit;
@@ -18,6 +19,57 @@ namespace WebApp.Tests
 
             Assert.NotNull(new Cost(usage1, usage2));
             Assert.NotNull(new Cost(usage2, usage1));
+        }
+
+        [Fact]
+        public void AllResourceGroupNamesAreExtractedFromRenderingEnvironment()
+        {
+            // make sure if any more AzureResource objects are added to 
+            // RenderingEnvironment, that ExtractResourceGroupNames is updated to match
+
+            int countPopulated = 0;
+            var env = PopulateEnv();
+
+            var rgNames = env.ExtractResourceGroupNames();
+
+            Assert.Equal(countPopulated, rgNames.Count());
+
+            RenderingEnvironment PopulateEnv()
+            {
+                var result = new RenderingEnvironment();
+                Populate(result);
+
+                result.Name = NextName();
+                return result;
+
+                void Populate(object o)
+                {
+                    if (o is AzureResource r)
+                    {
+                        // create a fake resource ID - RG name is 5th component
+                        r.ResourceId = "1/2/3/4/" + NextName();
+                    }
+
+                    foreach (var member in o.GetType().GetProperties().Where(p => p.CanWrite))
+                    {
+                        object inner;
+                        try
+                        {
+                            inner = Activator.CreateInstance(member.PropertyType);
+                        }
+                        catch
+                        {
+                            continue;
+                        }
+
+                        Populate(inner);
+
+                        member.SetValue(o, inner);
+                    }
+                }
+
+                string NextName() => "rg_" + (++countPopulated);
+            }
         }
     }
 }

--- a/src/AzureRenderManager/WebApp/Config/RenderingEnvironment.cs
+++ b/src/AzureRenderManager/WebApp/Config/RenderingEnvironment.cs
@@ -2,6 +2,8 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 using WebApp.Config.RenderManager;
@@ -74,4 +76,22 @@ namespace WebApp.Config
         Deleting,
         DeleteFailed
     }
+
+    public static class RenderingEnvironmentExtensions
+    {
+        public static IEnumerable<string> ExtractResourceGroupNames(this RenderingEnvironment env)
+            // note that resource group names are case-insensitive!
+            => AllResourceGroupNames(env).Distinct(StringComparer.OrdinalIgnoreCase);
+
+        private static IEnumerable<string> AllResourceGroupNames(RenderingEnvironment env)
+        {
+            yield return env.ApplicationInsightsAccount.ResourceGroupName;
+            yield return env.BatchAccount.ResourceGroupName;
+            yield return env.KeyVault.ResourceGroupName;
+            yield return env.ResourceGroupName;
+            yield return env.StorageAccount.ResourceGroupName;
+            yield return env.Subnet.ResourceGroupName;
+        }
+    }
+
 }

--- a/src/AzureRenderManager/WebApp/CostManagement/CostManagementClient.cs
+++ b/src/AzureRenderManager/WebApp/CostManagement/CostManagementClient.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text;
@@ -25,10 +23,14 @@ namespace WebApp.CostManagement
         private static Uri GetUri(string scope)
             => new Uri($"https://management.azure.com/{scope}/providers/Microsoft.CostManagement/query?api-version=2019-01-01");
 
-        public async Task<UsageResponse> GetUsageForSubscription(Guid subscriptionId, UsageRequest usageRequest)
-        {
-            var uri = GetUri($"subscriptions/{subscriptionId}");
+        public Task<UsageResponse> GetUsageForSubscription(Guid subscriptionId, UsageRequest usageRequest)
+            => PostUsageRequest(usageRequest, GetUri($"subscriptions/{subscriptionId}"));
 
+        public Task<UsageResponse> GetUsageForResourceGroup(Guid subscriptionId, string resourceGroupName, UsageRequest usageRequest)
+            => PostUsageRequest(usageRequest, GetUri($"subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}"));
+
+        private async Task<UsageResponse> PostUsageRequest(UsageRequest usageRequest, Uri uri)
+        {
             var request =
                 new HttpRequestMessage(HttpMethod.Post, uri)
                 {


### PR DESCRIPTION
In order to fetch costs from a subscription, the user must have access to the entire subscription, which is onerous. Instead we can request the cost from each resource group individually and merge them together. Luckily, the `Cost` type already has an aggregation constructor for totalling costs on the reporting page, so this is simple to implement in the `UsageCoordinator`.