### PR TITLE
Fix package routes and validation

### DIFF
--- a/src/AzureRenderManager/WebApp/Code/Extensions/InstallationPackageTypeExtension.cs
+++ b/src/AzureRenderManager/WebApp/Code/Extensions/InstallationPackageTypeExtension.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using WebApp.Config;
+
+namespace WebApp.Code.Extensions
+{
+    public static class InstallationPackageTypeExtension
+    {
+        public static bool HasInstallationCommand(this InstallationPackageType type)
+        {
+            return type == InstallationPackageType.General || type == InstallationPackageType.Gpu;
+        }
+    }
+}

--- a/src/AzureRenderManager/WebApp/Controllers/EnvironmentsController.cs
+++ b/src/AzureRenderManager/WebApp/Controllers/EnvironmentsController.cs
@@ -134,7 +134,7 @@ namespace WebApp.Controllers
         }
 
         [HttpGet]
-        [Route("Environments/Delete/{envId}")]
+        [Route("Environments/{envId}/Delete")]
         public async Task<ActionResult> Delete(string envId)
         {
             var environment = await _environmentCoordinator.GetEnvironment(envId);
@@ -178,6 +178,7 @@ namespace WebApp.Controllers
         /// <param name="model"></param>
         /// <returns></returns>
         [HttpPost]
+        [Route("Environments/{envId}/Delete")]
         public async Task<ActionResult> Delete(DeleteEnvironmentModel model)
         {
             if (model.EnvironmentName.Equals(model.Confirmation, StringComparison.OrdinalIgnoreCase) == false)

--- a/src/AzureRenderManager/WebApp/Models/Packages/AddGeneralPackageModel.cs
+++ b/src/AzureRenderManager/WebApp/Models/Packages/AddGeneralPackageModel.cs
@@ -10,13 +10,13 @@ namespace WebApp.Models.Packages
 {
     public class AddGeneralPackageModel
     {
-        [Required(ErrorMessage = "Package name is a required field")]
-        [RegularExpression(Validation.RegularExpressions.PackageName, ErrorMessage = Validation.Errors.Regex.PackageName)]
-        public string PackageName { get; set; }
+        //[Required(ErrorMessage = "Package name is a required field")]
+        //[RegularExpression(Validation.RegularExpressions.PackageName, ErrorMessage = Validation.Errors.Regex.PackageName)]
+        //public string PackageName { get; set; }
 
         public string InstallCommandLine { get; set; }
 
-        [Required]
+        //[Required]
         public IEnumerable<IFormFile> Files { get; set; }
     }
 }

--- a/src/AzureRenderManager/WebApp/Models/Packages/AddPackageModel.cs
+++ b/src/AzureRenderManager/WebApp/Models/Packages/AddPackageModel.cs
@@ -1,11 +1,19 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System.ComponentModel.DataAnnotations;
+using WebApp.Code;
+using WebApp.Config;
+
 namespace WebApp.Models.Packages
 {
     public class AddPackageModel
     {
+        [Required(ErrorMessage = "Package name is a required field")]
+        [RegularExpression(Validation.RegularExpressions.PackageName, ErrorMessage = Validation.Errors.Regex.PackageName)]
         public string PackageName { get; set; }
+
+        public InstallationPackageType? Type { get; set; }
 
         public AddGeneralPackageModel GeneralPackage { get; set; }
 

--- a/src/AzureRenderManager/WebApp/Models/Packages/AddQubePackageModel.cs
+++ b/src/AzureRenderManager/WebApp/Models/Packages/AddQubePackageModel.cs
@@ -10,21 +10,21 @@ namespace WebApp.Models.Packages
 {
     public class AddQubePackageModel
     {
-        [Required(ErrorMessage = "Package name is a required field")]
-        [RegularExpression(Validation.RegularExpressions.PackageName, ErrorMessage = Validation.Errors.Regex.PackageName)]
-        public string PackageName { get; set; }
+        //[Required(ErrorMessage = "Package name is a required field")]
+        //[RegularExpression(Validation.RegularExpressions.PackageName, ErrorMessage = Validation.Errors.Regex.PackageName)]
+        //public string PackageName { get; set; }
 
         public string InstallCommandLine { get; set; }
 
         public IFormFile QbConf { get; set; }
 
-        [Required]
+        //[Required]
         public IFormFile PythonInstaller { get; set; }
 
-        [Required]
+        //[Required]
         public IFormFile QubeCoreMsi { get; set; }
 
-        [Required]
+        //[Required]
         public IFormFile QubeWorkerMsi { get; set; }
 
         public IEnumerable<IFormFile> QubeJobTypeMsis { get; set; }

--- a/src/AzureRenderManager/WebApp/Models/Packages/ViewPackageModel.cs
+++ b/src/AzureRenderManager/WebApp/Models/Packages/ViewPackageModel.cs
@@ -17,7 +17,7 @@ namespace WebApp.Models.Packages
                 PackageName = package.PackageName;
                 InstallCommandLine = package.PackageInstallCommand;
                 Container = package.Container;
-                Type = package.Type.ToString();
+                Type = package.Type;
 
                 switch (package.Type)
                 {
@@ -53,7 +53,7 @@ namespace WebApp.Models.Packages
 
         public string Container { get; set; }
 
-        public string Type { get; set; }
+        public InstallationPackageType Type { get; set; }
 
         public string InstallCommandLine { get; set; }
 

--- a/src/AzureRenderManager/WebApp/Views/Packages/Add.cshtml
+++ b/src/AzureRenderManager/WebApp/Views/Packages/Add.cshtml
@@ -41,9 +41,9 @@
                 <div class="section-bar"></div>
                 <div class="section-content">
                     <div class="form-element">
-                        <label asp-for="QubePackage.PackageName">Package Name</label>
-                        <input asp-for="QubePackage.PackageName" placeholder="e.g. Qube 7.0" value="@Model.PackageName"/>
-                        <span asp-validation-for="QubePackage.PackageName" class=""></span>
+                        <label asp-for="PackageName">Package Name</label>
+                        <input asp-for="PackageName" placeholder="e.g. Qube 7.0" value="@Model.PackageName"/>
+                        <span asp-validation-for="PackageName" class=""></span>
                     </div>
                     <div class="form-element">
                         <label asp-for="QubePackage.PythonInstaller">Python Installer</label>
@@ -97,8 +97,8 @@
                 <div class="section-bar"></div>
                 <div class="section-content">
                     <div class="form-element">
-                        <label asp-for="QubePackage.PackageName">Package Name</label>
-                        <input asp-for="QubePackage.PackageName" placeholder="e.g. Qube 6.10"/>
+                        <label asp-for="PackageName">Package Name</label>
+                        <input asp-for="PackageName" placeholder="e.g. Qube 6.10"/>
                         <span asp-validation-for="PackageName" class=""></span>
                     </div>
                     <div class="form-element">
@@ -153,9 +153,9 @@
                 <div class="section-bar"></div>
                 <div class="section-content">
                     <div class="form-element">
-                        <label asp-for="GeneralPackage.PackageName">Package Name</label>
-                        <input asp-for="GeneralPackage.PackageName" placeholder="e.g. Deadline 10.0.12" value="Deadline10" />
-                        <span asp-validation-for="GeneralPackage.PackageName" class=""></span>
+                        <label asp-for="PackageName">Package Name</label>
+                        <input asp-for="PackageName" placeholder="e.g. Deadline 10.0.12" value="Deadline10" />
+                        <span asp-validation-for="PackageName" class=""></span>
                     </div>
                     <div class="form-element">
                         <label asp-for="GeneralPackage.Files">Deadline Client Installer (.exe)</label>
@@ -189,9 +189,9 @@
                 <div class="section-bar"></div>
                 <div class="section-content">
                     <div class="form-element">
-                        <label asp-for="GeneralPackage.PackageName">Package Name</label>
-                        <input asp-for="GeneralPackage.PackageName" placeholder="e.g. NVIDIA 398.75" value="NVIDIA-GPU"/>
-                        <span asp-validation-for="GeneralPackage.PackageName" class=""></span>
+                        <label asp-for="PackageName">Package Name</label>
+                        <input asp-for="PackageName" placeholder="e.g. NVIDIA 398.75" value="NVIDIA-GPU"/>
+                        <span asp-validation-for="PackageName" class=""></span>
                     </div>
                     <div class="form-element">
                         <label asp-for="GeneralPackage.Files">GPU Driver (.zip)</label>
@@ -233,9 +233,9 @@
                 <div class="section-bar"></div>
                 <div class="section-content">
                     <div class="form-element">
-                        <label asp-for="GeneralPackage.PackageName">Package Name</label>
-                        <input asp-for="GeneralPackage.PackageName" placeholder="e.g. Redshift" />
-                        <span asp-validation-for="GeneralPackage.PackageName" class=""></span>
+                        <label asp-for="PackageName">Package Name</label>
+                        <input asp-for="PackageName" placeholder="e.g. Redshift" />
+                        <span asp-validation-for="PackageName" class=""></span>
                     </div>
                     <div class="form-element">
                         <label asp-for="GeneralPackage.Files">Package Files</label>
@@ -261,16 +261,36 @@
 @section Scripts
 {
 <script>
-    $("#PackageTypes").change(function () {
-        // Disable all
-        $('#PackageTypes > option').each(function() {
-            var sectionToDisable = $(this).val();
-            $('#' + sectionToDisable).hide();
+    $(document).ready(function () {
+
+        if ('@Model.Type' !== '') {
+            var type = '@Model.Type'.toLowerCase();
+            $("#PackageTypes").val(type);
+        }
+
+        $("#PackageTypes").change(function () {
+            // Disable all
+            $('#PackageTypes > option').each(function () {
+                var sectionToDisable = $(this).val();
+                var divId = '#' + sectionToDisable;
+                $(divId).hide();
+                $(divId + " :input").attr("readonly", "readonly");
+                $(divId + " select").attr("disabled", "disabled");
+                $(divId + " :input[type='file']").attr("disabled", "disabled");
+            });
+
+            var c = $("#PackageTypes option:selected").val();
+            var divId = '#' + c;
+            console.log(c);
+
+            $(divId + " :input").removeAttr("readonly");
+            $(divId + " select").removeAttr("disabled");
+            $(divId + " :input[type='file']").removeAttr("disabled");
+            $(divId).show();
         });
 
-        var c = $("#PackageTypes option:selected").val();
-        console.log(c);
-        $('#' + c).show();
+        $("#PackageTypes").change();
     });
+
 </script>
 }

--- a/src/AzureRenderManager/WebApp/Views/Packages/Details.cshtml
+++ b/src/AzureRenderManager/WebApp/Views/Packages/Details.cshtml
@@ -1,4 +1,5 @@
-﻿@model WebApp.Models.Packages.ViewPackageModel
+﻿@using WebApp.Code.Extensions
+@model WebApp.Models.Packages.ViewPackageModel
 @{
     ViewBag.Title = Model.PackageName;
 }
@@ -36,11 +37,13 @@
                 <label asp-for="Container">Container Name</label>
                 <p>@Model.Container</p>
             </div>
-            <div class="form-element">
-                <label asp-for="Container">Install Command</label>
-                <p>@Model.InstallCommandLine</p>
-            </div>
-
+            @if (Model.Type.HasInstallationCommand())
+            {
+                <div class="form-element">
+                    <label asp-for="Container">Install Command</label>
+                    <p>@Model.InstallCommandLine</p>
+                </div>
+            }
             <div id="general" style="display: none;">
                 <div class="form-element">
                     <label asp-for="Container">Files</label>
@@ -76,7 +79,10 @@
 </div>
 <div class="form-footer">
     <div class="button-bar">
-        <a class="button" asp-controller="Packages" asp-action="Edit" asp-route-pkgId="@Model.PackageName">Edit Package <i class="fa fa-plus"></i></a>
+        @if (Model.Type.HasInstallationCommand())
+        {
+            <a class="button" asp-controller="Packages" asp-action="Edit" asp-route-pkgId="@Model.PackageName">Edit Package <i class="fa fa-plus"></i></a>
+        }
         <button type="button" onclick="performDelete('RenderManagerPackages', 'Delete', '@(Model.PackageName)')">Delete Package <i class="fa fa-trash"></i></button>
     </div>
 </div>

--- a/src/AzureRenderManager/WebApp/Views/Packages/Edit.cshtml
+++ b/src/AzureRenderManager/WebApp/Views/Packages/Edit.cshtml
@@ -10,7 +10,7 @@
 }
 
 <div class="page-header">
-    <h2>@Model.PackageName - edit</h2>
+    <h2>@Model.PackageName - Edit</h2>
     <p></p>
 </div>
 

--- a/src/AzureRenderManager/WebApp/Views/Shared/Menu/MainMenu.cshtml
+++ b/src/AzureRenderManager/WebApp/Views/Shared/Menu/MainMenu.cshtml
@@ -131,7 +131,7 @@
      */
     function performDelete(controller, action, id) {
         if (controller.toLowerCase() !== "environments") {
-            doDelete(id, `/${controller}/${id}/${action}`, `/${controller}/${id}/Overview`);
+            doDelete(id, `/${controller}/${id}/${action}`, `/${controller}`);
         } else {
             window.location.replace(`/${controller}/${id}/${action}`);
         }


### PR DESCRIPTION
Package validation was broken after upgrading to Asp.Net 2.2.
Fixed Package routes to align with environments.
Hide command line for Qube/DL packages.